### PR TITLE
Rename Piwik -> Matomo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Piwik/Decompress
+# Matomo/Decompress
 
 Component providing several adapters to decompress files.
 
-[![Build Status](https://travis-ci.org/piwik/component-decompress.svg?branch=master)](https://travis-ci.org/piwik/component-decompress)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/piwik/component-decompress/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/piwik/component-decompress/?branch=master)
+[![Build Status](https://travis-ci.org/matomo-org/component-decompress.svg?branch=master)](https://travis-ci.org/matomo-org/component-decompress)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/matomo-org/component-decompress/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/matomo-org/component-decompress/?branch=master)
 
 It supports the following compression formats:
 
@@ -25,17 +25,17 @@ With Composer:
 ```json
 {
     "require": {
-        "piwik/decompress": "*"
+        "matomo/decompress": "*"
     }
 }
 ```
 
 ## Usage
 
-All adapters have the same API as they implement `Piwik\Decompress\DecompressInterface`:
+All adapters have the same API as they implement `Matomo\Decompress\DecompressInterface`:
 
 ```php
-$extractor = new \Piwik\Decompress\Gzip('file.gz');
+$extractor = new \Matomo\Decompress\Gzip('file.gz');
 
 $extractedFiles = $extractor->extract('some/directory');
 

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "piwik/decompress",
+    "name": "matomo/decompress",
     "type": "library",
     "license": "LGPL-3.0",
     "autoload": {
         "psr-4": {
-            "Piwik\\Decompress\\": "src/"
+            "Matomo\\Decompress\\": "src/"
         },
         "classmap": ["libs/PclZip"]
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Piwik\\Decompress\\": "tests/"
+            "Tests\\Matomo\\Decompress\\": "tests/"
         }
     },
     "require": {

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,4 +1,4 @@
-## Piwik modifications to libs/
+## Matomo modifications to libs/
 
 In general, bug fixes and improvements are reported upstream.  Until these are
 included upstream, we maintain a list of bug fixes and local mods made to
@@ -6,6 +6,6 @@ third-party libraries:
 
  * PclZip/
    - line 1720, added possibility to define a callable for `PCLZIP_CB_PRE_EXTRACT`. Before one needed to pass a function name
-   - line 1789, convert to integer to avoid warning on PHP 7.1+ (see [#9](https://github.com/piwik/component-decompress/pull/9))
+   - line 1789, convert to integer to avoid warning on PHP 7.1+ (see [#9](https://github.com/matomo-org/component-decompress/pull/9))
    - line 3676, ignore touch() - utime failed warning
-   - line 5401, replaced `php_uname()` by `PHP_OS` (see [#2](https://github.com/piwik/component-decompress/issues/2))
+   - line 5401, replaced `php_uname()` by `PHP_OS` (see [#2](https://github.com/matomo-org/component-decompress/issues/2))

--- a/src/DecompressInterface.php
+++ b/src/DecompressInterface.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Decompress;
+namespace Matomo\Decompress;
 
 /**
  * Interface of a class that can decompress files.

--- a/src/Gzip.php
+++ b/src/Gzip.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Decompress;
+namespace Matomo\Decompress;
 
 /**
  * Unzip implementation for .gz files.

--- a/src/PclZip.php
+++ b/src/PclZip.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Decompress;
+namespace Matomo\Decompress;
 
 /**
  * Unzip wrapper around PclZip

--- a/src/Tar.php
+++ b/src/Tar.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Decompress;
+namespace Matomo\Decompress;
 
 use Archive_Tar;
 

--- a/src/ZipArchive.php
+++ b/src/ZipArchive.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Decompress;
+namespace Matomo\Decompress;
 
 use Exception;
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Decompress;
+namespace Tests\Matomo\Decompress;
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/GzipTest.php
+++ b/tests/GzipTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Decompress;
+namespace Tests\Matomo\Decompress;
 
-use Piwik\Decompress\Gzip;
+use Matomo\Decompress\Gzip;
 
 class GzipTest extends BaseTest
 {

--- a/tests/PclZipTest.php
+++ b/tests/PclZipTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Decompress;
+namespace Tests\Matomo\Decompress;
 
-use Piwik\Decompress\PclZip;
+use Matomo\Decompress\PclZip;
 
 class PclZipTest extends BaseTest
 {

--- a/tests/TarTest.php
+++ b/tests/TarTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Decompress;
+namespace Tests\Matomo\Decompress;
 
-use Piwik\Decompress\Tar;
+use Matomo\Decompress\Tar;
 
 class TarTest extends BaseTest
 {

--- a/tests/ZipArchiveTest.php
+++ b/tests/ZipArchiveTest.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Decompress;
+namespace Tests\Matomo\Decompress;
 
-use Piwik\Decompress\ZipArchive;
+use Matomo\Decompress\ZipArchive;
 
 class ZipArchiveTest extends BaseTest
 {


### PR DESCRIPTION
This fully renames Piwik to Matomo in this package. This includes all classes and namespaces.

We could already merge and release this as version 2.0 of this package, so we can release the new package to packagist.

Matomo currently requires version `1.*`, which then would need to be updated to `2.*` for Matomo 4