### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 sudo: false
 dist: trusty
@@ -17,6 +18,5 @@ matrix:
       dist: precise
 
 before_script:
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g -- disable-tls true || true'
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g -- secure-http false || true'
   - composer install
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "pear/archive_tar": "^1.4.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.4"
+        "phpunit/phpunit": "^4.8.36"
     }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -8,12 +8,14 @@
 
 namespace Tests\Matomo\Decompress;
 
-abstract class BaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTest extends TestCase
 {
     protected $fixtureDirectory;
     protected $tempDirectory;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -25,7 +27,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 
     protected function assertFileContentsEquals($expectedContent, $path)
     {
-        $this->assertTrue(file_exists($path));
+        $this->assertFileExists($path);
 
         $fd = fopen($path, 'rb');
         $actualContent = fread($fd, filesize($path));

--- a/tests/PclZipTest.php
+++ b/tests/PclZipTest.php
@@ -19,7 +19,7 @@ class PclZipTest extends BaseTest
 
         $unzip = new PclZip($filename);
         $res = $unzip->extract($this->tempDirectory);
-        $this->assertEquals(1, count($res));
+        $this->assertCount(1, $res);
         $this->assertFileExists($this->tempDirectory . $test . '.txt');
         $this->assertFileNotExists(__DIR__ . '/' . $test . '.txt');
         $this->assertFileNotExists(__DIR__ . '/../../tests/' . $test . '.txt');

--- a/tests/ZipArchiveTest.php
+++ b/tests/ZipArchiveTest.php
@@ -12,7 +12,7 @@ use Matomo\Decompress\ZipArchive;
 
 class ZipArchiveTest extends BaseTest
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -28,7 +28,7 @@ class ZipArchiveTest extends BaseTest
 
         $unzip = new ZipArchive($filename);
         $res = $unzip->extract($this->tempDirectory);
-        $this->assertEquals(1, count($res));
+        $this->assertCount(1, $res);
         $this->assertFileExists($this->tempDirectory . $test . '.txt');
         $this->assertFileNotExists(__DIR__ . '/' . $test . '.txt');
         $this->assertFileNotExists(__DIR__ . '/../../tests/' . $test . '.txt');


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test during Travis CI build.
- Removing unused `composer config` on `before_script` step during Travis CI build work.
- Using the `assertCount` to assert expected count is same as result.
- Using the `assertFileExists` to assert file is existed.
- Using the PHPUnit fixture method is `protected function setUp()`.
- To support future PHPUnit version, using the `PHPUnit` class namespace instead.
- Upgrading to the final `PHPUnit 4.x` version.