### PR TITLE
Ensure that failing fread won't cause a hanging process

### DIFF
--- a/src/Bzip.php
+++ b/src/Bzip.php
@@ -54,7 +54,14 @@ class Bzip implements DecompressInterface
 
         $output = fopen($pathExtracted, 'w');
         while (!feof($file)) {
-            fwrite($output, fread($file, 1024 * 1024));
+            $content = fread($file, 1024 * 1024);
+
+            if (false === $content) {
+                $this->error = "fread failed";
+                return false;
+            }
+            
+            fwrite($output, $content);
         }
         fclose($output);
 

--- a/src/Bzip.php
+++ b/src/Bzip.php
@@ -53,16 +53,20 @@ class Bzip implements DecompressInterface
         }
 
         $output = fopen($pathExtracted, 'w');
+
         while (!feof($file)) {
             $content = fread($file, 1024 * 1024);
 
             if (false === $content) {
                 $this->error = "fread failed";
+                fclose($output);
+                @unlink($pathExtracted);
                 return false;
             }
-            
+
             fwrite($output, $content);
         }
+
         fclose($output);
 
         $success = bzclose($file);

--- a/src/Gzip.php
+++ b/src/Gzip.php
@@ -54,7 +54,14 @@ class Gzip implements DecompressInterface
 
         $output = fopen($pathExtracted, 'w');
         while (!feof($file)) {
-            fwrite($output, fread($file, 1024 * 1024));
+            $content = fread($file, 1024 * 1024);
+
+            if (false === $content) {
+                $this->error = "fread failed";
+                return false;
+            }
+
+            fwrite($output, $content);
         }
         fclose($output);
 

--- a/src/Gzip.php
+++ b/src/Gzip.php
@@ -53,16 +53,20 @@ class Gzip implements DecompressInterface
         }
 
         $output = fopen($pathExtracted, 'w');
+
         while (!feof($file)) {
             $content = fread($file, 1024 * 1024);
 
             if (false === $content) {
                 $this->error = "fread failed";
+                fclose($output);
+                @unlink($pathExtracted);
                 return false;
             }
 
             fwrite($output, $content);
         }
+
         fclose($output);
 
         $success = gzclose($file);


### PR DESCRIPTION
### Description:

It may happen that for a corrupted file `fread` may return `false`, while the file end has not yet been reached.

This PR adds a better handling for that case, so extracting won't get stuck.

fixes #24
